### PR TITLE
fix: return status 0 on success

### DIFF
--- a/pwd_is_home.fish
+++ b/pwd_is_home.fish
@@ -1,6 +1,7 @@
 function pwd_is_home
     switch "$PWD"
         case ~{,/\*}
+          return 0
         case \*
           return 1
     end


### PR DESCRIPTION
Make pwd_is_home set $status to 0 when in or below $HOME,
regardless of the value of $status before.

After this commit:
~ > false; pwd_is_home; echo $status
0

Before this commit, the original $status was not touched when inside $HOME:
~ > false; pwd_is_home; echo $status
1
This made it seem as if outside $HOME when the last command before pwd_is_home failed.

Behavior was observed in:
~ > fish --version
fish, version 3.0.2